### PR TITLE
Validate the XML examples and fix them to conform

### DIFF
--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -1,0 +1,32 @@
+name: Validate XML examples
+
+on:
+  push:
+    paths:
+      - 'examples/**'
+      - 'schemas/**'
+      - 'assets/iso20022.org/**'
+      - '.github/workflows/validate-xml.yml'
+  pull_request:
+    paths:
+      - 'examples/**'
+      - 'schemas/**'
+      - 'assets/iso20022.org/**'
+      - '.github/workflows/validate-xml.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.x'
+      - run: pip install lxml openpyxl
+      - name: Unzip ISO external code sets
+        run: |
+          for z in assets/iso20022.org/*.zip; do unzip -o "$z" -d assets/iso20022.org/; done
+      - name: Generate external_codes.json from the workbook
+        run: python examples/validate.py --generate-codes
+      - name: Validate examples against schemas and code sets
+        run: python examples/validate.py

--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -28,5 +28,7 @@ jobs:
           for z in assets/iso20022.org/*.zip; do unzip -o "$z" -d assets/iso20022.org/; done
       - name: Generate external_codes.json from the workbook
         run: python examples/validate.py --generate-codes
+      - name: Self-check the validator
+        run: python examples/validate.py --selftest
       - name: Validate examples against schemas and code sets
         run: python examples/validate.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Generated at build/CI time from the tracked ISO code-sets zip — see examples/validate.md
+assets/iso20022.org/external_codes.json
+assets/iso20022.org/*.xlsx

--- a/examples/general/NRES_response.xml
+++ b/examples/general/NRES_response.xml
@@ -8,7 +8,7 @@
                         <head001:Othr>
                             <head001:Id>0245442-8</head001:Id>
                             <head001:SchmeNm>
-                                <head001:Cd>Y</head001:Cd>
+                                <head001:Cd>COID</head001:Cd>
                             </head001:SchmeNm>
                         </head001:Othr>
                     </head001:OrgId>
@@ -22,7 +22,7 @@
                         <head001:Othr>
                             <head001:Id>0245442-8</head001:Id>
                             <head001:SchmeNm>
-                                <head001:Cd>Y</head001:Cd>
+                                <head001:Cd>COID</head001:Cd>
                             </head001:SchmeNm>
                         </head001:Othr>
                     </head001:OrgId>
@@ -104,15 +104,18 @@
                             <head001:Othr>
                                 <head001:Id>0245442-8</head001:Id>
                                 <head001:SchmeNm>
-                                    <head001:Cd>Y</head001:Cd>
+                                    <head001:Cd>COID</head001:Cd>
                                 </head001:SchmeNm>
                             </head001:Othr>
                         </head001:OrgId>
                     </head001:Id>
                     <head001:CtctDtls>
-                        <head001:Nm>Virkailijan nimi</head001:Nm>
-                        <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                        <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                        <!-- Example value for the official's name -->
+                        <head001:Nm>Matti Meikäläinen</head001:Nm>
+                        <!-- Example value for a phone number -->
+                        <head001:PhneNb>+358-401234567</head001:PhneNb>
+                        <!-- Example value for email address (RFC2606) -->
+                        <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                     </head001:CtctDtls>
                 </head001:OrgId>
             </head001:Fr>
@@ -123,7 +126,7 @@
                             <head001:Othr>
                                 <head001:Id>0245442-8</head001:Id>
                                 <head001:SchmeNm>
-                                    <head001:Cd>Y</head001:Cd>
+                                    <head001:Cd>COID</head001:Cd>
                                 </head001:SchmeNm>
                             </head001:Othr>
                         </head001:OrgId>

--- a/examples/general/example_AppHdr.xml
+++ b/examples/general/example_AppHdr.xml
@@ -7,7 +7,7 @@
                     <head001:Othr>
                         <head001:Id>0245442-8</head001:Id>
                         <head001:SchmeNm>
-                            <head001:Cd>Y</head001:Cd>
+                            <head001:Cd>COID</head001:Cd>
                         </head001:SchmeNm>
                     </head001:Othr>
                 </head001:OrgId>
@@ -21,7 +21,7 @@
                     <head001:Othr>
                         <head001:Id>0245442-8</head001:Id>
                         <head001:SchmeNm>
-                            <head001:Cd>Y</head001:Cd>
+                            <head001:Cd>COID</head001:Cd>
                         </head001:SchmeNm>
                     </head001:Othr>
                 </head001:OrgId>
@@ -108,15 +108,18 @@
                         <head001:Othr>
                             <head001:Id>0245442-8</head001:Id>
                             <head001:SchmeNm>
-                                <head001:Cd>Y</head001:Cd>
+                                <head001:Cd>COID</head001:Cd>
                             </head001:SchmeNm>
                         </head001:Othr>
                     </head001:OrgId>
                 </head001:Id>
                 <head001:CtctDtls>
-                    <head001:Nm>Virkailijan nimi</head001:Nm>
-                    <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                    <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                    <!-- Example value for the official's name -->
+                    <head001:Nm>Matti Meikäläinen</head001:Nm>
+                    <!-- Example value for a phone number -->
+                    <head001:PhneNb>+358-401234567</head001:PhneNb>
+                    <!-- Example value for email address (RFC2606) -->
+                    <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                 </head001:CtctDtls>
             </head001:OrgId>
         </head001:Fr>
@@ -127,7 +130,7 @@
                         <head001:Othr>
                             <head001:Id>0245442-8</head001:Id>
                             <head001:SchmeNm>
-                                <head001:Cd>Y</head001:Cd>
+                                <head001:Cd>COID</head001:Cd>
                             </head001:SchmeNm>
                         </head001:Othr>
                     </head001:OrgId>

--- a/examples/general/example_passing_sender_details.xml
+++ b/examples/general/example_passing_sender_details.xml
@@ -117,7 +117,8 @@
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
                         <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
-                        <auth001:Dsclmr>Lakiperusteen kuvaus</auth001:Dsclmr>
+                        <!-- Example value for the description of the legal mandate basis -->
+                        <auth001:Dsclmr>Description of the legal mandate basis for the request</auth001:Dsclmr>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -146,9 +147,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Kyselevän viranomaisen tunniste</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>

--- a/examples/general/example_passing_sender_details.xml
+++ b/examples/general/example_passing_sender_details.xml
@@ -11,15 +11,18 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
                         </head001:Id>
                         <head001:CtctDtls>
-                            <head001:Nm>Virkailijan nimi</head001:Nm>
-                            <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                            <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                            <!-- Example value for the official's name -->
+                            <head001:Nm>Matti Meikäläinen</head001:Nm>
+                            <!-- Example value for a phone number -->
+                            <head001:PhneNb>+358-401234567</head001:PhneNb>
+                            <!-- Example value for email address (RFC2606) -->
+                            <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                         </head001:CtctDtls>
                     </head001:OrgId>
                 </head001:Fr>
@@ -30,7 +33,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -142,14 +145,14 @@
                         <auth001:Envlp>
                             <fin012:Document>
                                 <fin012:InfReqFin012>
+                                    <fin012:AuthorityInquiry>
+                                        <fin012:OfficialId>Kyselevän viranomaisen tunniste</fin012:OfficialId>
+                                        <fin012:OfficialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:OfficialSuperiorId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                    </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>
                                     </fin012:RequestedDataSources>
-                                    <fin012:AuthorityInquiry>
-                                        <fin012:officialId>Kyselevän viranomaisen tunniste</fin012:officialId>
-                                        <fin012:officialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:officialSuperiorId>
-                                        <fin012:officialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:officialOrgId>
-                                    </fin012:AuthorityInquiry>
                                 </fin012:InfReqFin012>
                             </fin012:Document>
                         </auth001:Envlp>

--- a/examples/general/example_request_additional_info.xml
+++ b/examples/general/example_request_additional_info.xml
@@ -39,7 +39,8 @@
                 <auth001:InfReqOpng>
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
-                        <auth001:Prgrph>testi</auth001:Prgrph>
+                        <!-- Example value for the legal mandate basis (statute reference) -->
+                        <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -68,9 +69,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Kyselevän viranomaisen tunniste</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:InvestigationType>
                                         <fin012:InvestigationTypeCode>BALN</fin012:InvestigationTypeCode>

--- a/examples/general/example_request_additional_info.xml
+++ b/examples/general/example_request_additional_info.xml
@@ -1,7 +1,40 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:root="urn:fi:customs:pmj:xsd:aggregator.002" xmlns:head001="urn:iso:std:iso:20022:tech:xsd:head.001.001.01" xmlns:auth001="urn:iso:std:iso:20022:tech:xsd:auth.001.001.01" xmlns:fin012="urn:fin.012.001.04">
     <soapenv:Body>
         <root:QueryRequest id="applicationRequest">
-            <head001:AppHdr>Include application header details..</head001:AppHdr>
+            <head001:AppHdr>
+                <head001:CharSet>UTF-8</head001:CharSet>
+                <head001:Fr>
+                    <head001:OrgId>
+                        <head001:Id>
+                            <head001:OrgId>
+                                <head001:Othr>
+                                    <head001:Id>0245442-8</head001:Id>
+                                    <head001:SchmeNm>
+                                        <head001:Cd>COID</head001:Cd>
+                                    </head001:SchmeNm>
+                                </head001:Othr>
+                            </head001:OrgId>
+                        </head001:Id>
+                    </head001:OrgId>
+                </head001:Fr>
+                <head001:To>
+                    <head001:OrgId>
+                        <head001:Id>
+                            <head001:OrgId>
+                                <head001:Othr>
+                                    <head001:Id>0245442-8</head001:Id>
+                                    <head001:SchmeNm>
+                                        <head001:Cd>COID</head001:Cd>
+                                    </head001:SchmeNm>
+                                </head001:Othr>
+                            </head001:OrgId>
+                        </head001:Id>
+                    </head001:OrgId>
+                </head001:To>
+                <head001:BizMsgIdr>8v96z4DKSVO4Zz66fKZrjg==</head001:BizMsgIdr>
+                <head001:MsgDefIdr>auth.001.001.01</head001:MsgDefIdr>
+                <head001:CreDt>2022-09-28T08:16:34.315328Z</head001:CreDt>
+            </head001:AppHdr>
             <auth001:Document>
                 <auth001:InfReqOpng>
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
@@ -35,9 +68,9 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:officialId>Kyselevän viranomaisen tunniste</fin012:officialId>
-                                        <fin012:officialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:officialSuperiorId>
-                                        <fin012:officialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:officialOrgId>
+                                        <fin012:OfficialId>Kyselevän viranomaisen tunniste</fin012:OfficialId>
+                                        <fin012:OfficialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:OfficialSuperiorId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:InvestigationType>
                                         <fin012:InvestigationTypeCode>BALN</fin012:InvestigationTypeCode>

--- a/examples/general/example_requesting_only_bal_or_entry_or_both.xml
+++ b/examples/general/example_requesting_only_bal_or_entry_or_both.xml
@@ -1,7 +1,40 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:root="urn:fi:customs:pmj:xsd:aggregator.002" xmlns:head001="urn:iso:std:iso:20022:tech:xsd:head.001.001.01" xmlns:auth001="urn:iso:std:iso:20022:tech:xsd:auth.001.001.01" xmlns:fin012="urn:fin.012.001.04">
     <soapenv:Body>
         <root:QueryRequest id="applicationRequest">
-            <head001:AppHdr>Include application header details..</head001:AppHdr>
+            <head001:AppHdr>
+                <head001:CharSet>UTF-8</head001:CharSet>
+                <head001:Fr>
+                    <head001:OrgId>
+                        <head001:Id>
+                            <head001:OrgId>
+                                <head001:Othr>
+                                    <head001:Id>0245442-8</head001:Id>
+                                    <head001:SchmeNm>
+                                        <head001:Cd>COID</head001:Cd>
+                                    </head001:SchmeNm>
+                                </head001:Othr>
+                            </head001:OrgId>
+                        </head001:Id>
+                    </head001:OrgId>
+                </head001:Fr>
+                <head001:To>
+                    <head001:OrgId>
+                        <head001:Id>
+                            <head001:OrgId>
+                                <head001:Othr>
+                                    <head001:Id>0245442-8</head001:Id>
+                                    <head001:SchmeNm>
+                                        <head001:Cd>COID</head001:Cd>
+                                    </head001:SchmeNm>
+                                </head001:Othr>
+                            </head001:OrgId>
+                        </head001:Id>
+                    </head001:OrgId>
+                </head001:To>
+                <head001:BizMsgIdr>8v96z4DKSVO4Zz66fKZrjg==</head001:BizMsgIdr>
+                <head001:MsgDefIdr>auth.001.001.01</head001:MsgDefIdr>
+                <head001:CreDt>2022-09-28T08:16:34.315328Z</head001:CreDt>
+            </head001:AppHdr>
             <auth001:Document>
                 <auth001:InfReqOpng>
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
@@ -34,6 +67,11 @@
                         <auth001:Envlp>
                             <fin012:Document>
                                 <fin012:InfReqFin012>
+                                    <fin012:AuthorityInquiry>
+                                        <fin012:OfficialId>Kyselevän viranomaisen tunniste</fin012:OfficialId>
+                                        <fin012:OfficialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:OfficialSuperiorId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                    </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>
                                     </fin012:RequestedDataSources>

--- a/examples/general/example_requesting_only_bal_or_entry_or_both.xml
+++ b/examples/general/example_requesting_only_bal_or_entry_or_both.xml
@@ -39,7 +39,8 @@
                 <auth001:InfReqOpng>
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
-                        <auth001:Prgrph>testi</auth001:Prgrph>
+                        <!-- Example value for the legal mandate basis (statute reference) -->
+                        <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -68,9 +69,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Kyselevän viranomaisen tunniste</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Kyselyn hyväksyjän tunniste</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml
@@ -117,7 +117,8 @@
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
                         <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
-                        <auth001:Dsclmr>Lakiperusteen kuvaus</auth001:Dsclmr>
+                        <!-- Example value for the description of the legal mandate basis -->
+                        <auth001:Dsclmr>Description of the legal mandate basis for the request</auth001:Dsclmr>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -146,9 +147,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:InvestigationType>
                                         <fin012:InvestigationTypeCode>BALN</fin012:InvestigationTypeCode>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml
@@ -11,15 +11,18 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
                         </head001:Id>
                         <head001:CtctDtls>
-                            <head001:Nm>Virkailijan nimi</head001:Nm>
-                            <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                            <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                            <!-- Example value for the official's name -->
+                            <head001:Nm>Matti Meikäläinen</head001:Nm>
+                            <!-- Example value for a phone number -->
+                            <head001:PhneNb>+358-401234567</head001:PhneNb>
+                            <!-- Example value for email address (RFC2606) -->
+                            <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                         </head001:CtctDtls>
                     </head001:OrgId>
                 </head001:Fr>
@@ -30,7 +33,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -145,7 +148,7 @@
                                     <fin012:AuthorityInquiry>
                                         <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
                                         <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:officialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:officialOrgId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:InvestigationType>
                                         <fin012:InvestigationTypeCode>BALN</fin012:InvestigationTypeCode>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml
@@ -11,15 +11,18 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
                         </head001:Id>
                         <head001:CtctDtls>
-                            <head001:Nm>Virkailijan nimi</head001:Nm>
-                            <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                            <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                            <!-- Example value for the official's name -->
+                            <head001:Nm>Matti Meikäläinen</head001:Nm>
+                            <!-- Example value for a phone number -->
+                            <head001:PhneNb>+358-401234567</head001:PhneNb>
+                            <!-- Example value for email address (RFC2606) -->
+                            <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                         </head001:CtctDtls>
                     </head001:OrgId>
                 </head001:Fr>
@@ -30,7 +33,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -130,7 +133,7 @@
                                     <auth001:Othr>
                                         <auth001:Id>OTHER8320134556001</auth001:Id>
                                         <auth001:SchmeNm>
-                                            <auth001:Cd>OTHR</auth001:Cd>
+                                            <auth001:Prtry>OTHER</auth001:Prtry>
                                         </auth001:SchmeNm>
                                     </auth001:Othr>
                                 </auth001:Id>
@@ -150,7 +153,7 @@
                                     <fin012:AuthorityInquiry>
                                         <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
                                         <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:officialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:officialOrgId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:InvestigationType>
                                         <fin012:InvestigationTypeCode>BALN</fin012:InvestigationTypeCode>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml
@@ -117,7 +117,8 @@
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
                         <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
-                        <auth001:Dsclmr>Lakiperusteen kuvaus</auth001:Dsclmr>
+                        <!-- Example value for the description of the legal mandate basis -->
+                        <auth001:Dsclmr>Description of the legal mandate basis for the request</auth001:Dsclmr>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -151,9 +152,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:InvestigationType>
                                         <fin012:InvestigationTypeCode>BALN</fin012:InvestigationTypeCode>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_response.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_response.xml
@@ -11,7 +11,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -25,7 +25,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -107,15 +107,18 @@
                                     <head001:Othr>
                                         <head001:Id>0245442-8</head001:Id>
                                         <head001:SchmeNm>
-                                            <head001:Cd>Y</head001:Cd>
+                                            <head001:Cd>COID</head001:Cd>
                                         </head001:SchmeNm>
                                     </head001:Othr>
                                 </head001:OrgId>
                             </head001:Id>
                             <head001:CtctDtls>
-                                <head001:Nm>Virkailijan nimi</head001:Nm>
-                                <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                                <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                                <!-- Example value for the official's name -->
+                                <head001:Nm>Matti Meikäläinen</head001:Nm>
+                                <!-- Example value for a phone number -->
+                                <head001:PhneNb>+358-401234567</head001:PhneNb>
+                                <!-- Example value for email address (RFC2606) -->
+                                <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                             </head001:CtctDtls>
                         </head001:OrgId>
                     </head001:Fr>
@@ -126,7 +129,7 @@
                                     <head001:Othr>
                                         <head001:Id>0245442-8</head001:Id>
                                         <head001:SchmeNm>
-                                            <head001:Cd>Y</head001:Cd>
+                                            <head001:Cd>COID</head001:Cd>
                                         </head001:SchmeNm>
                                     </head001:Othr>
                                 </head001:OrgId>
@@ -249,7 +252,7 @@
                                                         <camt052:Othr>
                                                             <camt052:Id>business id</camt052:Id>
                                                             <camt052:SchmeNm>
-                                                                <camt052:Cd>y</camt052:Cd>
+                                                                <camt052:Cd>COID</camt052:Cd>
                                                             </camt052:SchmeNm>
                                                         </camt052:Othr>
                                                     </camt052:OrgId>
@@ -277,7 +280,7 @@
                                                         <camt052:Othr>
                                                             <camt052:Id>business id</camt052:Id>
                                                             <camt052:SchmeNm>
-                                                                <camt052:Cd>y</camt052:Cd>
+                                                                <camt052:Prtry>Y-tunnus</camt052:Prtry>
                                                             </camt052:SchmeNm>
                                                         </camt052:Othr>
                                                     </camt052:FinInstnId>
@@ -361,7 +364,8 @@
                                                     <camt052:Btch>
                                                         <camt052:MsgId>MsgId</camt052:MsgId>
                                                         <camt052:PmtInfId>PmtInfId</camt052:PmtInfId>
-                                                        <camt052:NbOfTxs>Number of transactions in the batch</camt052:NbOfTxs>
+                                                        <!-- Number of transactions in the batch -->
+                                                        <camt052:NbOfTxs>2</camt052:NbOfTxs>
                                                         <camt052:TtlAmt Ccy="EUR">10000.00</camt052:TtlAmt>
                                                         <camt052:CdtDbtInd>CRDT</camt052:CdtDbtInd>
                                                     </camt052:Btch>
@@ -552,7 +556,7 @@
                                                             </camt052:CdtrAgt>
                                                         </camt052:RltdAgts>
                                                         <camt052:Purp>
-                                                            <camt052:Cd>DIVI</camt052:Cd>
+                                                            <camt052:Cd>DIVD</camt052:Cd>
                                                         </camt052:Purp>
                                                         <camt052:RmtInf>
                                                             <camt052:Ustrd>Free text max 140 characters</camt052:Ustrd>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_response.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_response.xml
@@ -387,7 +387,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -397,7 +398,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -454,7 +456,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -464,7 +467,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -521,7 +525,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -531,7 +536,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -588,7 +594,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -598,7 +605,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -685,7 +693,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -695,7 +704,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -782,7 +792,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -792,7 +803,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -879,7 +891,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -889,7 +902,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -976,7 +990,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -986,7 +1001,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml
@@ -383,10 +383,12 @@
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -396,7 +398,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -432,7 +435,8 @@
                                                             </camt52:Strd>
                                                         </camt52:RmtInf>
                                                         <camt52:RltdDts>
-                                                            <camt52:AccptncDtTm>2019-05-07T00:00:00Z</camt52:AccptncDtTm>
+                                                            <camt52:AccptncDtTm>2019-05-07T00:00:00Z
+                                                            </camt52:AccptncDtTm>
                                                         </camt52:RltdDts>
                                                     </camt52:TxDtls>
                                                     <camt52:TxDtls>
@@ -449,10 +453,12 @@
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -462,7 +468,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -515,10 +522,12 @@
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -528,7 +537,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -581,10 +591,12 @@
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -594,7 +606,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -677,10 +690,12 @@
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -690,7 +705,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -726,7 +742,8 @@
                                                             </camt52:Strd>
                                                         </camt52:RmtInf>
                                                         <camt52:RltdDts>
-                                                            <camt52:AccptncDtTm>2019-05-07T00:00:00Z</camt52:AccptncDtTm>
+                                                            <camt52:AccptncDtTm>2019-05-07T00:00:00Z
+                                                            </camt52:AccptncDtTm>
                                                         </camt52:RltdDts>
                                                     </camt52:TxDtls>
                                                 </camt52:NtryDtls>
@@ -773,10 +790,12 @@
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -786,7 +805,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -822,7 +842,8 @@
                                                             </camt52:Strd>
                                                         </camt52:RmtInf>
                                                         <camt52:RltdDts>
-                                                            <camt52:AccptncDtTm>2019-05-07T00:00:00Z</camt52:AccptncDtTm>
+                                                            <camt52:AccptncDtTm>2019-05-07T00:00:00Z
+                                                            </camt52:AccptncDtTm>
                                                         </camt52:RltdDts>
                                                     </camt52:TxDtls>
                                                 </camt52:NtryDtls>
@@ -869,10 +890,12 @@
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -882,7 +905,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>
@@ -965,10 +989,12 @@
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>
+                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Maksaja</camt52:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt52:Nm>Minttu Maksaja</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Dbtr>
                                                             <camt52:DbtrAcct>
@@ -978,7 +1004,8 @@
                                                             </camt52:DbtrAcct>
                                                             <camt52:Cdtr>
                                                                 <camt52:Pty>
-                                                                    <camt52:Nm>Saaja</camt52:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt52:Nm>Matti Virtanen</camt52:Nm>
                                                                 </camt52:Pty>
                                                             </camt52:Cdtr>
                                                             <camt52:CdtrAcct>

--- a/examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml
+++ b/examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml
@@ -12,7 +12,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -26,7 +26,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -108,15 +108,18 @@
                                     <head001:Othr>
                                         <head001:Id>0245442-8</head001:Id>
                                         <head001:SchmeNm>
-                                            <head001:Cd>Y</head001:Cd>
+                                            <head001:Cd>COID</head001:Cd>
                                         </head001:SchmeNm>
                                     </head001:Othr>
                                 </head001:OrgId>
                             </head001:Id>
                             <head001:CtctDtls>
-                                <head001:Nm>Virkailijan nimi</head001:Nm>
-                                <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                                <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                                <!-- Example value for the official's name -->
+                                <head001:Nm>Matti Meikäläinen</head001:Nm>
+                                <!-- Example value for a phone number -->
+                                <head001:PhneNb>+358-401234567</head001:PhneNb>
+                                <!-- Example value for email address (RFC2606) -->
+                                <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                             </head001:CtctDtls>
                         </head001:OrgId>
                     </head001:Fr>
@@ -127,7 +130,7 @@
                                     <head001:Othr>
                                         <head001:Id>0245442-8</head001:Id>
                                         <head001:SchmeNm>
-                                            <head001:Cd>Y</head001:Cd>
+                                            <head001:Cd>COID</head001:Cd>
                                         </head001:SchmeNm>
                                     </head001:Othr>
                                 </head001:OrgId>
@@ -238,7 +241,7 @@
                         </auth002:AuthrtyReqTp>
                         <auth002:InvstgtnRslt>
                             <auth002:Rslt>
-                                <camt52:Document xmlns:camt52="urn:iso:std:iso:20022:tech:xsd:camt.052.001.12">
+                                <camt52:Document xmlns:camt52="urn:iso:std:iso:20022:tech:xsd:camt.052.001.08">
                                     <camt52:BkToCstmrAcctRpt>
                                         <camt52:GrpHdr>
                                             <camt52:MsgId>MSG123456789</camt52:MsgId>
@@ -250,13 +253,13 @@
                                                         <camt52:Othr>
                                                             <camt52:Id>business id</camt52:Id>
                                                             <camt52:SchmeNm>
-                                                                <camt52:Cd>y</camt52:Cd>
+                                                                <camt52:Cd>COID</camt52:Cd>
                                                             </camt52:SchmeNm>
                                                         </camt52:Othr>
                                                     </camt52:OrgId>
                                                 </camt52:Id>
                                             </camt52:MsgRcpt>
-                                            <camt52:AddtInf>Additional information from sender</camt52:AddtInf>
+                                            <camt52:AddtlInf>Additional information from sender</camt52:AddtlInf>
                                         </camt52:GrpHdr>
                                         <camt52:Rpt>
                                             <camt52:Id>2026-01-01-04.44.12-EUR0123</camt52:Id>
@@ -278,7 +281,7 @@
                                                         <camt52:Othr>
                                                             <camt52:Id>business id</camt52:Id>
                                                             <camt52:SchmeNm>
-                                                                <camt52:Cd>y</camt52:Cd>
+                                                                <camt52:Prtry>Y-tunnus</camt52:Prtry>
                                                             </camt52:SchmeNm>
                                                         </camt52:Othr>
                                                     </camt52:FinInstnId>
@@ -333,7 +336,6 @@
                                             </camt52:TxsSummry>
                                             <camt52:Ntry>
                                                 <camt52:NtryRef>1</camt52:NtryRef>
-                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:Amt Ccy="EUR">10000.00</camt52:Amt>
                                                 <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                 <camt52:RvslInd>false</camt52:RvslInd>
@@ -346,10 +348,8 @@
                                                 <camt52:ValDt>
                                                     <camt52:DtTm>2019-05-08T00:00:00Z</camt52:DtTm>
                                                 </camt52:ValDt>
+                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:BkTxCd>
-                                                    <camt52:Prtry>
-                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
-                                                    </camt52:Prtry>
                                                     <camt52:Domn>
                                                         <camt52:Cd>PMNT</camt52:Cd>
                                                         <camt52:Fmly>
@@ -357,12 +357,15 @@
                                                             <camt52:SubFmlyCd>ESCT</camt52:SubFmlyCd>
                                                         </camt52:Fmly>
                                                     </camt52:Domn>
+                                                    <camt52:Prtry>
+                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
+                                                    </camt52:Prtry>
                                                 </camt52:BkTxCd>
                                                 <camt52:NtryDtls>
                                                     <camt52:Btch>
                                                         <camt52:MsgId>MsgId</camt52:MsgId>
                                                         <camt52:PmtInfId>PmtInfId</camt52:PmtInfId>
-                                                        <camt52:NbOfTxs>Number of transactions in the batch</camt52:NbOfTxs>
+                                                        <camt52:NbOfTxs>2</camt52:NbOfTxs>
                                                         <camt52:TtlAmt Ccy="EUR">10000.00</camt52:TtlAmt>
                                                         <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                     </camt52:Btch>
@@ -370,21 +373,17 @@
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">3300.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>USD</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -405,7 +404,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -421,6 +420,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -437,21 +439,17 @@
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">1500.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>USD</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -472,7 +470,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -488,6 +486,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -504,21 +505,17 @@
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">5800.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>USD</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -539,7 +536,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -555,6 +552,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -571,21 +571,17 @@
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">400.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>USD</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>USD</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.10</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -606,7 +602,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -622,6 +618,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -638,7 +637,6 @@
                                             </camt52:Ntry>
                                             <camt52:Ntry>
                                                 <camt52:NtryRef>2</camt52:NtryRef>
-                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:Amt Ccy="EUR">600.00</camt52:Amt>
                                                 <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                 <camt52:RvslInd>false</camt52:RvslInd>
@@ -651,10 +649,8 @@
                                                 <camt52:ValDt>
                                                     <camt52:DtTm>2019-05-08T00:00:00Z</camt52:DtTm>
                                                 </camt52:ValDt>
+                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:BkTxCd>
-                                                    <camt52:Prtry>
-                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
-                                                    </camt52:Prtry>
                                                     <camt52:Domn>
                                                         <camt52:Cd>PMNT</camt52:Cd>
                                                         <camt52:Fmly>
@@ -662,27 +658,26 @@
                                                             <camt52:SubFmlyCd>ESCT</camt52:SubFmlyCd>
                                                         </camt52:Fmly>
                                                     </camt52:Domn>
+                                                    <camt52:Prtry>
+                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
+                                                    </camt52:Prtry>
                                                 </camt52:BkTxCd>
                                                 <camt52:NtryDtls>
                                                     <camt52:TxDtls>
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">600.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>EUR</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -703,7 +698,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -719,6 +714,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -735,7 +733,6 @@
                                             </camt52:Ntry>
                                             <camt52:Ntry>
                                                 <camt52:NtryRef>3</camt52:NtryRef>
-                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:Amt Ccy="EUR">600.00</camt52:Amt>
                                                 <camt52:CdtDbtInd>CRDT</camt52:CdtDbtInd>
                                                 <camt52:RvslInd>false</camt52:RvslInd>
@@ -748,10 +745,8 @@
                                                 <camt52:ValDt>
                                                     <camt52:DtTm>2019-05-08T00:00:00Z</camt52:DtTm>
                                                 </camt52:ValDt>
+                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:BkTxCd>
-                                                    <camt52:Prtry>
-                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
-                                                    </camt52:Prtry>
                                                     <camt52:Domn>
                                                         <camt52:Cd>PMNT</camt52:Cd>
                                                         <camt52:Fmly>
@@ -759,27 +754,26 @@
                                                             <camt52:SubFmlyCd>ESCT</camt52:SubFmlyCd>
                                                         </camt52:Fmly>
                                                     </camt52:Domn>
+                                                    <camt52:Prtry>
+                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
+                                                    </camt52:Prtry>
                                                 </camt52:BkTxCd>
                                                 <camt52:NtryDtls>
                                                     <camt52:TxDtls>
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">600.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>EUR</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -800,7 +794,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -816,6 +810,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -832,7 +829,6 @@
                                             </camt52:Ntry>
                                             <camt52:Ntry>
                                                 <camt52:NtryRef>4</camt52:NtryRef>
-                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:Amt Ccy="EUR">400.00</camt52:Amt>
                                                 <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
                                                 <camt52:RvslInd>false</camt52:RvslInd>
@@ -845,10 +841,8 @@
                                                 <camt52:ValDt>
                                                     <camt52:DtTm>2019-05-08T00:00:00Z</camt52:DtTm>
                                                 </camt52:ValDt>
+                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:BkTxCd>
-                                                    <camt52:Prtry>
-                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
-                                                    </camt52:Prtry>
                                                     <camt52:Domn>
                                                         <camt52:Cd>PMNT</camt52:Cd>
                                                         <camt52:Fmly>
@@ -856,27 +850,26 @@
                                                             <camt52:SubFmlyCd>ESCT</camt52:SubFmlyCd>
                                                         </camt52:Fmly>
                                                     </camt52:Domn>
+                                                    <camt52:Prtry>
+                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
+                                                    </camt52:Prtry>
                                                 </camt52:BkTxCd>
                                                 <camt52:NtryDtls>
                                                     <camt52:TxDtls>
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">400.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>EUR</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -897,7 +890,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -913,6 +906,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>
@@ -929,7 +925,6 @@
                                             </camt52:Ntry>
                                             <camt52:Ntry>
                                                 <camt52:NtryRef>5</camt52:NtryRef>
-                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:Amt Ccy="EUR">1000.00</camt52:Amt>
                                                 <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
                                                 <camt52:RvslInd>false</camt52:RvslInd>
@@ -942,10 +937,8 @@
                                                 <camt52:ValDt>
                                                     <camt52:DtTm>2019-05-08T00:00:00Z</camt52:DtTm>
                                                 </camt52:ValDt>
+                                                <camt52:AcctSvcrRef>1234</camt52:AcctSvcrRef>
                                                 <camt52:BkTxCd>
-                                                    <camt52:Prtry>
-                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
-                                                    </camt52:Prtry>
                                                     <camt52:Domn>
                                                         <camt52:Cd>PMNT</camt52:Cd>
                                                         <camt52:Fmly>
@@ -953,27 +946,26 @@
                                                             <camt52:SubFmlyCd>ESCT</camt52:SubFmlyCd>
                                                         </camt52:Fmly>
                                                     </camt52:Domn>
+                                                    <camt52:Prtry>
+                                                        <camt52:Cd>7xxTEXT</camt52:Cd>
+                                                    </camt52:Prtry>
                                                 </camt52:BkTxCd>
                                                 <camt52:NtryDtls>
                                                     <camt52:TxDtls>
                                                         <camt52:Refs>
                                                             <camt52:InstrId>Debitor ref</camt52:InstrId>
                                                         </camt52:Refs>
+                                                        <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
                                                         <camt52:AmtDtls>
                                                             <camt52:TxAmt>
                                                                 <camt52:Amt Ccy="EUR">1000.00</camt52:Amt>
                                                                 <camt52:CcyXchg>
-                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:SrcCcy>EUR</camt52:SrcCcy>
+                                                                    <camt52:UnitCcy>EUR</camt52:UnitCcy>
                                                                     <camt52:XchgRate>1.00</camt52:XchgRate>
                                                                 </camt52:CcyXchg>
                                                             </camt52:TxAmt>
-                                                        </camt52:AmtDtls>
-                                                        <camt52:CdtDbtInd>DBIT</camt52:CdtDbtInd>
-                                                        <camt52:Purp>
-                                                            <camt52:Cd>ExternalPurpose1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
-                                                        </camt52:Purp>
-                                                        <camt52:RltdPties>
+                                                        </camt52:AmtDtls>                                                        <camt52:RltdPties>
                                                             <camt52:Dbtr>
                                                                 <camt52:Pty>
                                                                     <camt52:Nm>Maksaja</camt52:Nm>
@@ -994,7 +986,7 @@
                                                                     <camt52:IBAN>FI2447066587000379</camt52:IBAN>
                                                                 </camt52:Id>
                                                                 <camt52:Tp>
-                                                                    <camt52:Cd>ExternalCashAccountType1Code</camt52:Cd> | <camt52:Prtry>Max35Text</camt52:Prtry>
+                                                                    <camt52:Cd>CACC</camt52:Cd>
                                                                 </camt52:Tp>
                                                             </camt52:CdtrAcct>
                                                         </camt52:RltdPties>
@@ -1010,6 +1002,9 @@
                                                                 </camt52:FinInstnId>
                                                             </camt52:CdtrAgt>
                                                         </camt52:RltdAgts>
+                                                        <camt52:Purp>
+                                                            <camt52:Cd>OTHR</camt52:Cd>
+                                                        </camt52:Purp>
                                                         <camt52:RmtInf>
                                                             <camt52:Ustrd>Free text max 140 characters</camt52:Ustrd>
                                                             <camt52:Strd>

--- a/examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml
+++ b/examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml
@@ -11,15 +11,18 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
                         </head001:Id>
                         <head001:CtctDtls>
-                            <head001:Nm>Virkailijan nimi</head001:Nm>
-                            <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                            <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                            <!-- Example value for the official's name -->
+                            <head001:Nm>Matti Meikäläinen</head001:Nm>
+                            <!-- Example value for a phone number -->
+                            <head001:PhneNb>+358-401234567</head001:PhneNb>
+                            <!-- Example value for email address (RFC2606) -->
+                            <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                         </head001:CtctDtls>
                     </head001:OrgId>
                 </head001:Fr>
@@ -30,7 +33,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -145,7 +148,7 @@
                                     <fin012:AuthorityInquiry>
                                         <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
                                         <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:officialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:officialOrgId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>

--- a/examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml
+++ b/examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml
@@ -117,7 +117,8 @@
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
                         <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
-                        <auth001:Dsclmr>Lakiperusteen kuvaus</auth001:Dsclmr>
+                        <!-- Example value for the description of the legal mandate basis -->
+                        <auth001:Dsclmr>Description of the legal mandate basis for the request</auth001:Dsclmr>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -146,9 +147,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>

--- a/examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml
+++ b/examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml
@@ -1,4 +1,4 @@
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:root="urn:fi:customs:pmj:xsd:aggregator.002" xmlns:urn1="urn:iso:std:iso:20022:tech:xsd:head.001.001.01" xmlns:auth001="urn:iso:std:iso:20022:tech:xsd:auth.001.001.01" xmlns:fin012="urn:fin.012.001.04">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:root="urn:fi:customs:pmj:xsd:aggregator.002" xmlns:head001="urn:iso:std:iso:20022:tech:xsd:head.001.001.01" xmlns:auth001="urn:iso:std:iso:20022:tech:xsd:auth.001.001.01" xmlns:fin012="urn:fin.012.001.04">
     <soapenv:Header/>
     <soapenv:Body>
         <root:QueryRequest id="applicationRequest">
@@ -11,15 +11,18 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
                         </head001:Id>
                         <head001:CtctDtls>
-                            <head001:Nm>Virkailijan nimi</head001:Nm>
-                            <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                            <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                            <!-- Example value for the official's name -->
+                            <head001:Nm>Matti Meikäläinen</head001:Nm>
+                            <!-- Example value for a phone number -->
+                            <head001:PhneNb>+358-401234567</head001:PhneNb>
+                            <!-- Example value for email address (RFC2606) -->
+                            <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                         </head001:CtctDtls>
                     </head001:OrgId>
                 </head001:Fr>
@@ -30,7 +33,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -130,7 +133,7 @@
                                     <auth001:Othr>
                                         <auth001:Id>OTHER8320134556001</auth001:Id>
                                         <auth001:SchmeNm>
-                                            <auth001:Cd>OTHR</auth001:Cd>
+                                            <auth001:Prtry>OTHER</auth001:Prtry>
                                         </auth001:SchmeNm>
                                     </auth001:Othr>
                                 </auth001:Id>
@@ -150,7 +153,7 @@
                                     <fin012:AuthorityInquiry>
                                         <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
                                         <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:officialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:officialOrgId>
+                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>

--- a/examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml
+++ b/examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml
@@ -117,7 +117,8 @@
                     <auth001:InvstgtnId>ABC1234</auth001:InvstgtnId>
                     <auth001:LglMndtBsis>
                         <auth001:Prgrph>111/2000_1_11_2</auth001:Prgrph>
-                        <auth001:Dsclmr>Lakiperusteen kuvaus</auth001:Dsclmr>
+                        <!-- Example value for the description of the legal mandate basis -->
+                        <auth001:Dsclmr>Description of the legal mandate basis for the request</auth001:Dsclmr>
                     </auth001:LglMndtBsis>
                     <auth001:CnfdtltySts>true</auth001:CnfdtltySts>
                     <auth001:InvstgtnPrd>
@@ -151,9 +152,12 @@
                             <fin012:Document>
                                 <fin012:InfReqFin012>
                                     <fin012:AuthorityInquiry>
-                                        <fin012:OfficialId>Viranomaisen nimi</fin012:OfficialId>
-                                        <fin012:OfficialSuperiorId>Esimiehen nimi</fin012:OfficialSuperiorId>
-                                        <fin012:OfficialOrgId>Kyselevän viranomaisen organisaation tunniste</fin012:OfficialOrgId>
+                                        <!-- Example value for the identification of the official sending the request -->
+                                        <fin012:OfficialId>Matti Meikäläinen</fin012:OfficialId>
+                                        <!-- Example value for the identification of the official approving the request -->
+                                        <fin012:OfficialSuperiorId>Liisa Virtanen</fin012:OfficialSuperiorId>
+                                        <!-- Example value for the organisation identification of the requesting authority -->
+                                        <fin012:OfficialOrgId>1234567-8</fin012:OfficialOrgId>
                                     </fin012:AuthorityInquiry>
                                     <fin012:RequestedDataSources>
                                         <fin012:DataSourceOrgId>0788060-2</fin012:DataSourceOrgId>

--- a/examples/queries_and_responses/data_users/Camt_052_result_response.xml
+++ b/examples/queries_and_responses/data_users/Camt_052_result_response.xml
@@ -11,7 +11,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -25,7 +25,7 @@
                                 <head001:Othr>
                                     <head001:Id>0245442-8</head001:Id>
                                     <head001:SchmeNm>
-                                        <head001:Cd>Y</head001:Cd>
+                                        <head001:Cd>COID</head001:Cd>
                                     </head001:SchmeNm>
                                 </head001:Othr>
                             </head001:OrgId>
@@ -107,15 +107,18 @@
                                     <head001:Othr>
                                         <head001:Id>0245442-8</head001:Id>
                                         <head001:SchmeNm>
-                                            <head001:Cd>Y</head001:Cd>
+                                            <head001:Cd>COID</head001:Cd>
                                         </head001:SchmeNm>
                                     </head001:Othr>
                                 </head001:OrgId>
                             </head001:Id>
                             <head001:CtctDtls>
-                                <head001:Nm>Virkailijan nimi</head001:Nm>
-                                <head001:PhneNb>Virkailijan puhelinnumero</head001:PhneNb>
-                                <head001:EmailAdr>Virkailijan sähköpostiosoite<head001:EmailAdr>
+                                <!-- Example value for the official's name -->
+                                <head001:Nm>Matti Meikäläinen</head001:Nm>
+                                <!-- Example value for a phone number -->
+                                <head001:PhneNb>+358-401234567</head001:PhneNb>
+                                <!-- Example value for email address (RFC2606) -->
+                                <head001:EmailAdr>matti.meikalainen@example.com</head001:EmailAdr>
                             </head001:CtctDtls>
                         </head001:OrgId>
                     </head001:Fr>
@@ -126,7 +129,7 @@
                                     <head001:Othr>
                                         <head001:Id>0245442-8</head001:Id>
                                         <head001:SchmeNm>
-                                            <head001:Cd>Y</head001:Cd>
+                                            <head001:Cd>COID</head001:Cd>
                                         </head001:SchmeNm>
                                     </head001:Othr>
                                 </head001:OrgId>
@@ -265,7 +268,7 @@
                                                         <camt052:Othr>
                                                             <camt052:Id>business id</camt052:Id>
                                                             <camt052:SchmeNm>
-                                                                <camt052:Cd>y</camt052:Cd>
+                                                                <camt052:Cd>COID</camt052:Cd>
                                                             </camt052:SchmeNm>
                                                         </camt052:Othr>
                                                     </camt052:OrgId>
@@ -293,7 +296,7 @@
                                                         <camt052:Othr>
                                                             <camt052:Id>business id</camt052:Id>
                                                             <camt052:SchmeNm>
-                                                                <camt052:Cd>y</camt052:Cd>
+                                                                <camt052:Prtry>Y-tunnus</camt052:Prtry>
                                                             </camt052:SchmeNm>
                                                         </camt052:Othr>
                                                     </camt052:FinInstnId>
@@ -377,7 +380,7 @@
                                                     <camt052:Btch>
                                                         <camt052:MsgId>MsgId</camt052:MsgId>
                                                         <camt052:PmtInfId>PmtInfId</camt052:PmtInfId>
-                                                        <camt052:NbOfTxs>Number of transactions in the batch</camt052:NbOfTxs>
+                                                        <camt052:NbOfTxs>2</camt052:NbOfTxs>
                                                         <camt052:TtlAmt Ccy="EUR">10000.00</camt052:TtlAmt>
                                                         <camt052:CdtDbtInd>CRDT</camt052:CdtDbtInd>
                                                     </camt052:Btch>
@@ -568,7 +571,7 @@
                                                             </camt052:CdtrAgt>
                                                         </camt052:RltdAgts>
                                                         <camt052:Purp>
-                                                            <camt052:Cd>DIVI</camt052:Cd>
+                                                            <camt052:Cd>DIVD</camt052:Cd>
                                                         </camt052:Purp>
                                                         <camt052:RmtInf>
                                                             <camt052:Ustrd>Free text max 140 characters</camt052:Ustrd>

--- a/examples/queries_and_responses/data_users/Camt_052_result_response.xml
+++ b/examples/queries_and_responses/data_users/Camt_052_result_response.xml
@@ -402,7 +402,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -412,7 +413,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -469,7 +471,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -479,7 +482,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -536,7 +540,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -546,7 +551,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -603,7 +609,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -613,7 +620,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -700,7 +708,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -710,7 +719,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -797,7 +807,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -807,7 +818,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -894,7 +906,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -904,7 +917,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>
@@ -991,7 +1005,8 @@
                                                         <camt052:RltdPties>
                                                             <camt052:Dbtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Maksaja</camt052:Nm>
+                                                                    <!-- Example value for the debtor's name -->
+                                                                    <camt052:Nm>Minttu Maksaja</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Dbtr>
                                                             <camt052:DbtrAcct>
@@ -1001,7 +1016,8 @@
                                                             </camt052:DbtrAcct>
                                                             <camt052:Cdtr>
                                                                 <camt052:Pty>
-                                                                    <camt052:Nm>Saaja</camt052:Nm>
+                                                                    <!-- Example value for the creditor's name -->
+                                                                    <camt052:Nm>Matti Virtanen</camt052:Nm>
                                                                 </camt052:Pty>
                                                             </camt052:Cdtr>
                                                             <camt052:CdtrAcct>

--- a/examples/validate.md
+++ b/examples/validate.md
@@ -1,0 +1,80 @@
+# `validate.py` — example validator
+
+Validates every XML file under `examples/` against the XSD schemas in `schemas/`
+and against the ISO 20022 External Code Sets. Used as the CI gate for this repo.
+
+## What it checks
+
+1. **Schema (XSD).** Builds a catalog `{(namespace, root element): schema}` from
+   `schemas/*.xsd`, then validates every `AppHdr` / `Document` subtree it finds —
+   so SOAP-wrapped messages and standalone headers are all covered without any
+   per-file configuration.
+2. **Value formats.** A few fields are typed as free-form text in the schema
+   (e.g. `head.001` `EmailAdr` is `Max2048Text` with no pattern). `VALUE_CHECKS`
+   adds format checks so example *values* stay realistic, not just well-formed.
+3. **External code values.** ISO types many `<Cd>` fields as `External*Code`,
+   which the XSD treats as an unconstrained string — so a wrong code (e.g. `DIVI`
+   for `DIVD`, `Y` for `COID`) passes XSD untouched. `resolve_codeset()` infers
+   the applicable code set from each `<Cd>`'s context and checks membership
+   against `external_codes.json` (see [Code sets](#code-sets)).
+
+Exit code is non-zero if any subtree fails validation, any file is malformed, or
+any `<Cd>` is not a valid member of its code set. Files whose namespace has no
+schema here (e.g. `register.003`) are reported `UNMATCHED` but do not fail.
+
+**It does not stop at the first problem.** A recovering XML parser is used, so a
+single run reports *every* issue in *every* file — all well-formedness errors,
+then the schema/value/code issues found on the best-effort recovered tree —
+rather than aborting a file at its first error. Fix the `[well-formedness]`
+issues first: some structural errors below them are cascade artifacts of a
+malformed tag and disappear once the file parses cleanly. The summary line
+reports files-with-issues, total issues, and unmatched counts.
+
+## Requirements
+
+- **Python** 3.x
+- **[`lxml`](https://pypi.org/project/lxml/)** — XSD validation (libxml2); required to run the validator.
+- **[`openpyxl`](https://pypi.org/project/openpyxl/)** — only for `--generate-codes` (reading the ISO workbook); *not* needed to validate.
+- Standard library only otherwise: `json`, `re`, `pathlib`, `sys`.
+
+```sh
+pip install lxml            # to validate
+pip install lxml openpyxl   # to also regenerate the code sets
+```
+
+## Usage
+
+```sh
+python examples/validate.py                   # validate the repo (CI entry point)
+python examples/validate.py --selftest        # built-in self-check
+python examples/validate.py --generate-codes  # (re)build assets/iso20022.org/external_codes.json
+```
+
+If `assets/iso20022.org/external_codes.json` is missing, validation still runs
+but prints a `NOTE` and skips the external-code check (structure and value
+checks still apply).
+
+## Code sets
+
+`assets/iso20022.org/external_codes.json` holds the ISO External Code Sets the examples use.
+It is **generated and gitignored**, not committed. The tracked source is the
+zip in `assets/iso20022.org/` (e.g. `ExternalCodeSets_XLSX_November_2025_v2.zip`).
+
+To (re)generate locally:
+
+```sh
+unzip -o assets/iso20022.org/*.zip -d assets/iso20022.org/  # -> *.xlsx (gitignored)
+python examples/validate.py --generate-codes                # -> assets/iso20022.org/external_codes.json
+```
+
+Update the code sets by dropping a newer ISO zip into `assets/iso20022.org/` and
+re-running the two commands. To validate more `External*Code` fields, add the
+field's context to `resolve_codeset()` and its code-set name to `CODE_SETS` in
+`validate.py`, then regenerate.
+
+## Continuous integration
+
+The GitHub Action **[`.github/workflows/validate-xml.yml`](../.github/workflows/validate-xml.yml)**
+runs on every push / pull request that touches `examples/`, `schemas/`, or
+`assets/iso20022.org/`. It installs `lxml` + `openpyxl`, unzips the code-sets
+zip, runs `--generate-codes`, then runs the validator.

--- a/examples/validate.md
+++ b/examples/validate.md
@@ -9,9 +9,13 @@ and against the ISO 20022 External Code Sets. Used as the CI gate for this repo.
    `schemas/*.xsd`, then validates every `AppHdr` / `Document` subtree it finds —
    so SOAP-wrapped messages and standalone headers are all covered without any
    per-file configuration.
-2. **Value formats.** A few fields are typed as free-form text in the schema
-   (e.g. `head.001` `EmailAdr` is `Max2048Text` with no pattern). `VALUE_CHECKS`
-   adds format checks so example *values* stay realistic, not just well-formed.
+2. **Value formats.** Some fields have a format the XSD type doesn't fully pin
+   down — free-form text (`head.001` `EmailAdr` is `Max2048Text` with no pattern)
+   or timestamps that are valid `xs:dateTime` but not required to be UTC (the
+   `camt.052` `ISODateTime` fields, unlike `head.001`, don't require a `Z`).
+   `VALUE_CHECKS` adds a regex per field so example *values* stay realistic and
+   consistent (e.g. emails look like emails, timestamps are `…Z`), not just
+   structurally valid.
 3. **External code values.** ISO types many `<Cd>` fields as `External*Code`,
    which the XSD treats as an unconstrained string — so a wrong code (e.g. `DIVI`
    for `DIVD`, `Y` for `COID`) passes XSD untouched. `resolve_codeset()` infers

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Validate every XML under examples/ against the XSD schemas in schemas/.
+
+Each schema declares exactly one global root element (Document or AppHdr) in its
+own targetNamespace, and the schemas do not import each other. Most examples are
+SOAP envelopes that carry the ISO 20022 messages (AppHdr + Document) nested
+inside soap:Body, so validating a whole file against a single schema is not
+possible.
+
+Instead, we build a catalog {(namespace, localname): schema} from the schemas,
+then walk each example and validate every element whose (namespace, localname)
+matches a catalog entry. That transparently covers SOAP-wrapped messages,
+standalone AppHdr/Document files, and any schema/example added later -- no
+per-file mapping to maintain.
+
+Value checks (VALUE_CHECKS): some leaf fields are typed as free-form text in the
+schema (e.g. head.001 EmailAdr is Max2048Text with no pattern), so the XSD alone
+would accept placeholder prose. VALUE_CHECKS adds a format check for such fields
+so the example *values* stay realistic, not just structurally valid.
+
+External code checks (external_codes.json): ISO types many <Cd> fields as
+External*Code, which the XSD treats as an unconstrained string -- so a wrong code
+(DIVI for DIVD, Y for COID, or a code where only Prtry is valid) passes XSD
+untouched. resolve_codeset() derives the applicable ISO code set from each <Cd>'s
+context, and we check membership against external_codes.json, extracted from the
+ISO External Code Sets workbook. Regenerate that file when the workbook updates;
+see the comment above EXTERNAL_CODES.
+
+Exit code is non-zero if any matched element fails validation or any file is not
+well-formed. Files with no matching schema are reported as UNMATCHED (a visible
+gap, e.g. register.003 which has no schema here) but do not fail the run.
+
+Usage:
+    python examples/validate.py                  # validate the repo
+    python examples/validate.py --generate-codes # (re)build assets/iso20022.org/external_codes.json
+    python examples/validate.py --selftest       # run the built-in self-check
+"""
+import json
+import re
+import sys
+from pathlib import Path
+from re import Pattern
+
+try:
+    from lxml import etree  # XSD validation needs libxml2; stdlib xml cannot do it
+except ImportError:
+    sys.exit("lxml is required: pip install lxml")
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS_DIR = ROOT / "schemas"
+EXAMPLES_DIR = ROOT / "examples"
+XSD_ELEMENT = "{http://www.w3.org/2001/XMLSchema}element"
+HEAD_NS = "urn:iso:std:iso:20022:tech:xsd:head.001.001.01"
+
+# Format checks for leaf fields the schema leaves as free-form text (Max*Text)
+# but which carry a well-known format, so example values stay realistic.
+# ponytail: one entry today (EmailAdr); add a row if another free-text field
+# needs its example values constrained.
+VALUE_CHECKS: dict[tuple[str, str], tuple[Pattern[str], str]] = {
+    (HEAD_NS, "EmailAdr"): (re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+"), "not a valid email address"),
+}
+
+# ISO External Code Sets used by the examples' <Cd> fields, keyed by code-set name.
+# external_codes.json is generated and gitignored: unzip the tracked
+# assets/iso20022.org/*.zip there, then run  python examples/validate.py --generate-codes
+CODES_SRC_DIR = ROOT / "assets" / "iso20022.org"
+CODES_FILE = CODES_SRC_DIR / "external_codes.json"
+# Code sets resolve_codeset() maps to. ExternalFinancialInstitutionIdentification1Code
+# is not published by ISO, so it is stored empty (any <Cd> there is flagged).
+CODE_SETS = [
+    "ExternalEntryStatus1Code",
+    "ExternalPurpose1Code",
+    "ExternalCashAccountType1Code",
+    "ExternalBalanceType1Code",
+    "ExternalOrganisationIdentification1Code",
+    "ExternalAccountIdentification1Code",
+]
+try:
+    EXTERNAL_CODES = {k: set(v) for k, v in json.loads(CODES_FILE.read_text(encoding="utf-8")).items()}
+except FileNotFoundError:
+    EXTERNAL_CODES = {}
+
+
+def build_catalog(schemas_dir=SCHEMAS_DIR):
+    """Map (targetNamespace, root element name) -> (schema filename, XMLSchema)."""
+    catalog = {}
+    for xsd in sorted(schemas_dir.glob("*.xsd")):
+        doc = etree.parse(str(xsd))
+        tns = doc.getroot().get("targetNamespace")
+        schema = etree.XMLSchema(doc)
+        for el in doc.getroot():
+            if el.tag == XSD_ELEMENT and el.get("name"):
+                catalog[(tns, el.get("name"))] = (xsd.name, schema)
+    return catalog
+
+
+def _qname(el):
+    """QName of an element, or None if its tag is not a resolvable qualified name.
+
+    The recovering parser can leave elements with unresolved-prefix tags (e.g.
+    'head001:AppHdr' when the prefix was never declared); etree.QName raises on
+    those, so callers treat them as unrecognised and skip them.
+    """
+    if not isinstance(el.tag, str):  # comments / processing instructions
+        return None
+    try:
+        return etree.QName(el)
+    except ValueError:
+        return None
+
+
+def resolve_codeset(el):
+    """Return the ISO external code set a <Cd> element must belong to, or None.
+
+    The code set is not in the XML; it is fixed by the field's position, so we
+    infer it from the parent (and, for scheme codes, the nearest identifying
+    ancestor). Fields we don't recognise return None and are left unchecked --
+    e.g. bank-transaction Domn/Fmly codes, which live in a separate ISO list.
+    """
+    q = _qname(el)
+    if q is None or q.localname != "Cd":
+        return None
+    parent = el.getparent()
+    pq = _qname(parent) if parent is not None else None
+    if pq is None:
+        return None
+    simple = {
+        "Sts": "ExternalEntryStatus1Code",
+        "Purp": "ExternalPurpose1Code",
+        "CdOrPrtry": "ExternalBalanceType1Code",  # only under Bal/Tp in these messages
+        "Tp": "ExternalCashAccountType1Code",     # only under CdtrAcct/DbtrAcct here
+    }
+    if pq.localname in simple:
+        return simple[pq.localname]
+    if pq.localname == "SchmeNm":
+        ancestors = set()
+        p = parent
+        while p is not None:
+            aq = _qname(p)
+            if aq is not None:
+                ancestors.add(aq.localname)
+            p = p.getparent()
+        if "FinInstnId" in ancestors:
+            return "ExternalFinancialInstitutionIdentification1Code"
+        if "OrgId" in ancestors:
+            return "ExternalOrganisationIdentification1Code"
+        if "Acct" in ancestors:
+            return "ExternalAccountIdentification1Code"
+    return None
+
+
+def validate_file(xml_path, catalog):
+    """Return list of (label, ok, message) for well-formedness, schema, value and
+    code checks. A recovering parser is used so one run reports *all* problems in
+    a file -- every well-formedness error, plus the schema/value/code issues found
+    on the best-effort recovered tree -- instead of stopping at the first.
+
+    Schema hits report ok=True/False; well-formedness/value/code entries are
+    appended only on failure. message is None when ok, else a relative-safe string.
+    """
+    results = []
+    parser = etree.XMLParser(recover=True)
+    tree = etree.parse(str(xml_path), parser)
+    seen_wf = set()
+    for e in parser.error_log:
+        detail = f"{e.line}:{e.column}: {e.message}"
+        if detail not in seen_wf:
+            seen_wf.add(detail)
+            results.append(("well-formedness", False, detail))
+    if tree.getroot() is None:  # nothing recoverable
+        return results
+    for el in tree.iter():
+        q = _qname(el)
+        if q is None:  # comment, PI, or recovery artifact with an unresolved prefix
+            continue
+        key = (q.namespace, q.localname)
+
+        hit = catalog.get(key)
+        if hit:
+            schema_name, schema = hit
+            if schema.validate(el):
+                results.append((schema_name, True, None))
+            else:
+                # Report every error libxml2 collected for this subtree, not just
+                # the last one, so a single run gives the complete picture. Each
+                # error stringifies with an absolute filename, so rebuild it from
+                # the fields (only the relative path, added in main, is shown).
+                seen = set()
+                for e in schema.error_log:  # reset per validate(); no cross-subtree bleed
+                    detail = f"{e.line}:{e.column}:{e.level_name}:{e.domain_name}:{e.type_name}: {e.message}"
+                    if detail not in seen:
+                        seen.add(detail)
+                        results.append((schema_name, False, detail))
+
+        check = VALUE_CHECKS.get(key)
+        if check:
+            pattern, desc = check
+            text = (el.text or "").strip()
+            if not pattern.fullmatch(text):
+                results.append((f"value:{q.localname}", False, f"{desc}: {text!r}"))
+
+        codeset = resolve_codeset(el)
+        if codeset in EXTERNAL_CODES:
+            code = (el.text or "").strip()
+            if code not in EXTERNAL_CODES[codeset]:
+                hint = "" if EXTERNAL_CODES[codeset] else " (no such ISO code set -- use Prtry)"
+                results.append((f"code:{codeset}", False, f"{code!r} is not a valid {codeset}{hint}"))
+    return results
+
+
+def main():
+    catalog = build_catalog()
+    if not catalog:
+        sys.exit(f"No schemas found in {SCHEMAS_DIR}")
+    if not EXTERNAL_CODES:
+        print(f"NOTE  {CODES_FILE.name} not found -- external <Cd> values not checked.\n")
+
+    xmls = sorted(EXAMPLES_DIR.rglob("*.xml"))
+    issues = 0            # total problems across all files
+    failed_files = 0      # files with at least one problem
+    unmatched = 0
+    for xml in xmls:
+        rel = xml.relative_to(ROOT)
+        results = validate_file(xml, catalog)
+        if not results:
+            print(f"UNMATCHED  {rel}: no schema for its namespace(s)")
+            unmatched += 1
+            continue
+        file_issues = 0
+        for label, ok, message in results:
+            if ok:
+                print(f"OK    {rel}  [{label}]")
+            else:
+                print(f"FAIL  {rel}  [{label}]: {message}")
+                file_issues += 1
+        issues += file_issues
+        if file_issues:
+            failed_files += 1
+
+    print(f"\n{len(xmls)} file(s): {failed_files} with issues, "
+          f"{issues} issue(s) total, {unmatched} unmatched.")
+    return 1 if issues else 0
+
+
+def selftest():
+    """Self-check: catalog builds, XSD catches a broken subtree, value checks work."""
+    catalog = build_catalog()
+    assert catalog, "catalog is empty"
+    assert (HEAD_NS, "AppHdr") in catalog
+    assert ("urn:iso:std:iso:20022:tech:xsd:camt.052.001.08", "Document") in catalog
+
+    # XSD: an empty Document (missing required children) must fail its schema.
+    ns = "urn:iso:std:iso:20022:tech:xsd:camt.052.001.08"
+    _, schema = catalog[(ns, "Document")]
+    assert not schema.validate(etree.fromstring(f'<Document xmlns="{ns}"/>'))
+
+    # Value check: EmailAdr must look like an email, not placeholder prose.
+    email_re, _ = VALUE_CHECKS[(HEAD_NS, "EmailAdr")]
+    assert email_re.fullmatch("matti.meikalainen@example.com")
+    assert not email_re.fullmatch("Virkailijan sähköpostiosoite")
+
+    # Code-set context resolution works without the generated data...
+    org_cd = etree.fromstring(
+        f'<AppHdr xmlns="{HEAD_NS}"><Fr><OrgId><Id><OrgId><Othr>'
+        "<Id>x</Id><SchmeNm><Cd>Y</Cd></SchmeNm></Othr></OrgId></Id></OrgId></Fr></AppHdr>"
+    ).find(f".//{{{HEAD_NS}}}Cd")
+    assert resolve_codeset(org_cd) == "ExternalOrganisationIdentification1Code"
+    # ...and membership is enforced once external_codes.json has been generated.
+    if EXTERNAL_CODES:
+        assert "COID" in EXTERNAL_CODES["ExternalOrganisationIdentification1Code"]
+        assert "Y" not in EXTERNAL_CODES["ExternalOrganisationIdentification1Code"]
+        assert "DIVD" in EXTERNAL_CODES["ExternalPurpose1Code"]
+        assert "DIVI" not in EXTERNAL_CODES["ExternalPurpose1Code"]
+    else:
+        print("  (external_codes.json not generated -- code membership not checked)")
+
+    # Every real example parses and its matched elements resolve.
+    for xml in EXAMPLES_DIR.rglob("*.xml"):
+        validate_file(xml, catalog)
+
+    print("selftest OK")
+    return 0
+
+
+def generate_codes():
+    """Regenerate external_codes.json from the ISO code-sets workbook in assets/.
+
+    Reads the .xlsx extracted from the tracked assets/iso20022.org/*.zip (the
+    GitHub Action unzips it first). Both the .xlsx and the generated JSON are
+    gitignored; only the .zip is tracked.
+    """
+    try:
+        import openpyxl  # only needed to regenerate, not to validate
+    except ImportError:
+        sys.exit("openpyxl is required for --generate-codes: pip install openpyxl")
+    xlsxs = sorted(CODES_SRC_DIR.glob("*.xlsx"))
+    if not xlsxs:
+        sys.exit(f"no .xlsx in {CODES_SRC_DIR} -- unzip the External Code Sets .zip there first")
+
+    wb = openpyxl.load_workbook(xlsxs[0], read_only=True, data_only=True)
+    sets = {}
+    for i, row in enumerate(wb["AllCodeSets"].iter_rows(values_only=True)):
+        if i == 0 or not row[0]:
+            continue
+        sets.setdefault(str(row[0]).strip(), set()).add(str(row[1] or "").strip())
+
+    out = {name: sorted(sets.get(name, set())) for name in CODE_SETS}
+    out["ExternalFinancialInstitutionIdentification1Code"] = []  # not published by ISO
+    CODES_FILE.write_text(
+        json.dumps(out, indent=1, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {CODES_FILE.relative_to(ROOT)}: "
+          f"{len(out)} code sets, {sum(len(v) for v in out.values())} codes")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--generate-codes" in sys.argv:
+        sys.exit(generate_codes())
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -13,10 +13,12 @@ matches a catalog entry. That transparently covers SOAP-wrapped messages,
 standalone AppHdr/Document files, and any schema/example added later -- no
 per-file mapping to maintain.
 
-Value checks (VALUE_CHECKS): some leaf fields are typed as free-form text in the
-schema (e.g. head.001 EmailAdr is Max2048Text with no pattern), so the XSD alone
-would accept placeholder prose. VALUE_CHECKS adds a format check for such fields
-so the example *values* stay realistic, not just structurally valid.
+Value checks (VALUE_CHECKS): some leaf fields have a well-known format the XSD
+type does not fully pin down -- free-form text (e.g. head.001 EmailAdr is
+Max2048Text with no pattern) or timestamps that are valid xs:dateTime but not
+required to be UTC (the camt.052 ISODateTime fields, unlike head.001, do not
+require a "Z"). VALUE_CHECKS adds a regex per (namespace, localname) so the
+example *values* stay realistic and consistent, not just structurally valid.
 
 External code checks (external_codes.json): ISO types many <Cd> fields as
 External*Code, which the XSD treats as an unconstrained string -- so a wrong code
@@ -51,13 +53,33 @@ SCHEMAS_DIR = ROOT / "schemas"
 EXAMPLES_DIR = ROOT / "examples"
 XSD_ELEMENT = "{http://www.w3.org/2001/XMLSchema}element"
 HEAD_NS = "urn:iso:std:iso:20022:tech:xsd:head.001.001.01"
+CAMT_NS = "urn:iso:std:iso:20022:tech:xsd:camt.052.001.08"
+AUTH1_NS = "urn:iso:std:iso:20022:tech:xsd:auth.001.001.01"
 
-# Format checks for leaf fields the schema leaves as free-form text (Max*Text)
-# but which carry a well-known format, so example values stay realistic.
-# ponytail: one entry today (EmailAdr); add a row if another free-text field
-# needs its example values constrained.
+# Value-format checks: (namespace, localname) -> (regex, message). The value must
+# fully match the regex. These catch wrong-looking values the XSD type accepts.
+#
+# Timestamps/dates are typed xs:dateTime / xs:date, so the XSD already rejects
+# impossible dates -- but only head.001 requires UTC ("Z" suffix); the camt.052
+# ISODateTime fields do not, while every example (and the head.001 convention)
+# uses "...Z". The checks below enforce that UTC convention and a plain date form.
+# (A parse-based check is deliberately avoided: xs:dateTime allows "24:00:00",
+# which Python's strptime rejects, so a regex on the lexical shape is safer.)
+_UTC_DATETIME = (re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z"),
+                 "not an ISO-8601 UTC timestamp (YYYY-MM-DDThh:mm:ss[.ffffff]Z)")
+_DATE = (re.compile(r"\d{4}-\d{2}-\d{2}"), "not an ISO-8601 date (YYYY-MM-DD)")
 VALUE_CHECKS: dict[tuple[str, str], tuple[Pattern[str], str]] = {
     (HEAD_NS, "EmailAdr"): (re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+"), "not a valid email address"),
+    (HEAD_NS, "CreDt"): _UTC_DATETIME,
+    (CAMT_NS, "CreDtTm"): _UTC_DATETIME,
+    (CAMT_NS, "DtTm"): _UTC_DATETIME,
+    (CAMT_NS, "FrDtTm"): _UTC_DATETIME,
+    (CAMT_NS, "ToDtTm"): _UTC_DATETIME,
+    (CAMT_NS, "AccptncDtTm"): _UTC_DATETIME,
+    (CAMT_NS, "FrDt"): _DATE,
+    (CAMT_NS, "ToDt"): _DATE,
+    (AUTH1_NS, "FrDt"): _DATE,
+    (AUTH1_NS, "ToDt"): _DATE,
 }
 
 # ISO External Code Sets used by the examples' <Cd> fields, keyed by code-set name.
@@ -258,6 +280,18 @@ def selftest():
     email_re, _ = VALUE_CHECKS[(HEAD_NS, "EmailAdr")]
     assert email_re.fullmatch("matti.meikalainen@example.com")
     assert not email_re.fullmatch("Virkailijan sähköpostiosoite")
+
+    # Timestamp check: UTC datetimes (incl. 24:00:00 and fractions) pass; a
+    # missing "Z", an offset, or junk fails.
+    dt_re, _ = VALUE_CHECKS[(CAMT_NS, "CreDtTm")]
+    assert dt_re.fullmatch("2019-05-08T24:00:00Z")
+    assert dt_re.fullmatch("2022-09-28T08:16:34.315328Z")
+    assert not dt_re.fullmatch("2019-05-08T00:00:00")        # no Z -> not UTC
+    assert not dt_re.fullmatch("2019-05-08T00:00:00+02:00")  # offset, not Z
+    assert not dt_re.fullmatch("not-a-timestamp")
+    date_re, _ = VALUE_CHECKS[(AUTH1_NS, "FrDt")]
+    assert date_re.fullmatch("2020-09-01")
+    assert not date_re.fullmatch("2020-09-01T00:00:00Z")
 
     # Code-set context resolution works without the generated data...
     org_cd = etree.fromstring(

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -336,7 +336,9 @@ def generate_codes():
     for i, row in enumerate(wb["AllCodeSets"].iter_rows(values_only=True)):
         if i == 0 or not row[0]:
             continue
-        sets.setdefault(str(row[0]).strip(), set()).add(str(row[1] or "").strip())
+        code = str(row[1] or "").strip()
+        if code:  # skip rows with no code value -- an empty <Cd/> must not validate
+            sets.setdefault(str(row[0]).strip(), set()).add(code)
 
     out = {name: sorted(sets.get(name, set())) for name in CODE_SETS}
     out["ExternalFinancialInstitutionIdentification1Code"] = []  # not published by ISO


### PR DESCRIPTION

## Summary

Adds a validator that checks every XML file under `examples/` against the XSD schemas in `schemas/` **and** against the ISO 20022 External Code Sets, wires it into CI, and fixes all of the existing examples so they pass. Before this, the examples had well-formedness bugs, schema-ordering/version mismatches, and several invalid ISO codes that no XSD catches (because those fields are typed as free-form `External*Code` strings).

## Commits

1. **Add validator and CI for XML examples** — `examples/validate.py` (+ `validate.md`), the GitHub Action, and `.gitignore`.
2. **Fix examples to pass schema and code-set validation** — 11 example files: ordering, casing, well-formedness, valid headers, valid codes, representative values.
3. **Convert data-disclosure response example to camt.052.001.08** — the one example that was authored against camt.052.001.**12**.
4. **Add timestamp and date format checks to the example validator** — enforce the UTC/date conventions the XSD leaves open.
5. **Generalise example placeholder values and translate them to English** — replace the remaining Finnish placeholders with representative values and add field comments.

## What changed and why

### 1. Validator + CI (`examples/validate.py`, `validate.md`, workflow)

- Builds a catalog from the schemas and validates every `AppHdr` / `Document`
  subtree it finds, so SOAP-wrapped and standalone messages are both covered
  with no per-file configuration.
- **Value checks** for fields whose format the XSD type doesn't fully pin down:
  free-text fields with an obvious format (e.g. `EmailAdr`), and timestamps/dates
  (`CreDt`, `CreDtTm`, `DtTm`, `FrDt`, …) — the XSD rejects impossible dates, but
  only `head.001` requires UTC, while every example uses `…Z`, so the checks
  enforce that convention.
- **External code checks**: many `<Cd>` fields are typed `External*Code`, which
  the XSD treats as any string. The validator resolves the applicable ISO code
  set from each field's context and checks membership against the published code
  list — this is what catches the invalid codes below.
- Reports **all** issues per file in one run (recovering parser) instead of
  stopping at the first, so a full triage is visible at once.
- CI (`.github/workflows/validate-xml.yml`) unzips the tracked ISO code-sets
  zip, generates the code list, and runs the validator on every push/PR that
  touches `examples/`, `schemas/`, or the code sets.

### 2. Example fixes (11 files)

- **Well-formedness**: an `EmailAdr` end tag was written as a start tag; a
  namespace prefix was declared under one name but used under another.
- **Schema conformance**: corrected `fin.012` element order (`AuthorityInquiry`
  must precede `RequestedDataSources`, and was missing in one file); fixed
  element casing (`officialOrgId` → `OfficialOrgId`); gave the illustrative
  `general/example_*` request snippets real, valid application headers in place
  of placeholder prose; made `NbOfTxs` a number instead of prose.
- **Valid ISO codes** (see open questions): `Y`/`y` → `COID`, `DIVI` → `DIVD`,
  and account/FI scheme codes moved to `Prtry`.
- **Representative values + comments**: consistent example contact details with
  explanatory comments describing what each field expects.

### 3. camt.052.001.12 → .08 conversion (1 file)

`Camt_052_response_for_data_disclosure_system.xml` embedded a sub-message
declared as **camt.052.001.12**, while the spec, the shipped schema, and every
other example use **.08**. Converted it to .08: reordered `AcctSvcrRef`,
`BkTxCd`, `CcyXchg`, `CdtDbtInd`, and `Purp` to the .08 sequence, and resolved
the choice-stub placeholders it contained. It now validates against the shipped
`.08` schema.

### 4. Example values generalised & translated to English

The remaining Finnish placeholder values were translated to English and replaced
with representative example values, each with a short comment describing what the
field expects (matching the existing "Example value for …" style):

- Authority-inquiry identifications (the official sending the request, the
  official approving it, and the requesting organisation).
- Legal-mandate-basis paragraph reference and description.
- Debtor / creditor party names in the response examples.

Person names and identifiers throughout are generic placeholders, not real data.

---

## ⚠️ Open questions — please review before merge

These are the points where a value was **chosen or invented** and needs a domain
owner's confirmation. None of them are caught by the schema; the validator only
guarantees they are *valid ISO codes*, not that they are the *intended* ones.

1. **`Y`/`y` → `COID` (organisation-id scheme, ~all files).** `Y` is not a valid
   `ExternalOrganisationIdentification1Code`. The identifier is a Finnish
   **Y-tunnus** (business ID `0245442-8`); `COID` = "country-authority given
   organisation identification (e.g. corporate registration number)" is the
   closest ISO code. **Confirm `COID` is the intended scheme.**

2. **`OTHR`/`CACC` in the disclosure example.** The .12 sub-message was a
   structural template with `<Cd>TypeName</Cd> | <Prtry>…</Prtry>` choice stubs.
   These were resolved to `Purp` = **`OTHR`** (Other) and account `Tp` = **`CACC`**
   (Current account). **These are best-guess representative codes — verify.**

3. **Proprietary (`Prtry`) substitutions.** Two ISO code sets have no valid
   `Cd` for these examples, so a `Prtry` value was used instead:
   - Financial-institution scheme → `<Prtry>Y-tunnus</Prtry>` (there is *no*
     `ExternalFinancialInstitutionIdentification1Code` set in ISO's workbook).
   - "Query by OTHER identifier" account scheme → `<Prtry>OTHER</Prtry>`
     (`ExternalAccountIdentification1Code` is only `AIIN/BBAN/CUID/UPIC`).
   **Confirm these proprietary values match the real schemes.**

4. **`DIVI` → `DIVD`.** `DIVI` (Dividend) exists only in *CategoryPurpose*, not
   in `ExternalPurpose1Code`; the equivalent Purpose code is `DIVD`. Low risk,
   but flagged for completeness.

5. **Placeholder-but-valid values remain in the disclosure example.** These pass
   the schema (free-text fields) but are clearly template stubs — Tulli may want
   real data: `InstrId` = "Debitor ref", `RmtInf/Ustrd` = "Free text max 140
   characters", `CdtrRefInf/Ref` = "Max35Text", and a nonsensical self-exchange
   (`USD→USD` / `EUR→EUR` at rate 1.10 / 1.00).

6. **Bank-transaction codes are not validated.** `PMNT` (Domn), `RCDT` (Fmly),
   and `ESCT` (SubFmlyCd) are published in ISO's **separate** Bank Transaction
   Codes list, not the External Code Sets workbook — so the validator cannot
   check them. They were left unchanged; **verify against that separate list.**

7. **Illustrative snippets were fleshed out.** The `general/example_*` request
   examples previously had prose-only application headers ("Include application
   header details.."). They now carry complete, valid headers so they validate.
   **Confirm that's preferred over keeping them as minimal illustrations.**

8. **Example names and identifiers are placeholders.** Person names, the
   organisation id (`1234567-8`), and similar values are generic representative
   placeholders, not real reference data. **Confirm none need to be real values.**

9. **Timestamps are enforced as UTC.** The validator requires every timestamp to
   end in `Z`. The `camt.052` schema does not require this (only `head.001`
   does), though all examples use it. **Confirm `camt.052` timestamps are always
   UTC.**

---

## How to run

```sh
pip install lxml                                # to validate
python examples/validate.py                     # 12 file(s): 0 with issues, 0 unmatched
python examples/validate.py --selftest          # tool self-check
```

Regenerating the code list (maintainer, needs `openpyxl`) and CI both unzip the
tracked ISO zip and run `python examples/validate.py --generate-codes`; the
generated `external_codes.json` and the extracted `.xlsx` are gitignored.

---

## `validate.py` results

_Output of `python examples/validate.py` before and after the changes on this branch._

**Before (base branch):**

```text
➜ python examples/validate.py
FAIL  examples/general/NRES_response.xml  [well-formedness]: 116:40: Opening and ending tag mismatch: EmailAdr line 115 and CtctDtls
FAIL  examples/general/NRES_response.xml  [well-formedness]: 117:33: Opening and ending tag mismatch: EmailAdr line 115 and OrgId
FAIL  examples/general/NRES_response.xml  [well-formedness]: 118:26: Opening and ending tag mismatch: CtctDtls line 112 and Fr
FAIL  examples/general/NRES_response.xml  [well-formedness]: 204:24: Opening and ending tag mismatch: OrgId line 101 and Rltd
FAIL  examples/general/NRES_response.xml  [well-formedness]: 205:22: Opening and ending tag mismatch: Fr line 100 and AppHdr
FAIL  examples/general/NRES_response.xml  [well-formedness]: 236:28: Opening and ending tag mismatch: Rltd line 98 and ApplicationResponse
FAIL  examples/general/NRES_response.xml  [head.001.001.01.xsd]: 114:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/general/NRES_response.xml  [head.001.001.01.xsd]: 115:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/general/NRES_response.xml  [head.001.001.01.xsd]: 119:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/general/NRES_response.xml  [head.001.001.01.xsd]: 206:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.002.001.01}Document': This element is not expected. Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/general/NRES_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/NRES_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/NRES_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/NRES_response.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/general/NRES_response.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/general/NRES_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/general/NRES_response.xml  [auth.002.001.01.xsd]
FAIL  examples/general/example_AppHdr.xml  [well-formedness]: 120:36: Opening and ending tag mismatch: EmailAdr line 119 and CtctDtls
FAIL  examples/general/example_AppHdr.xml  [well-formedness]: 121:29: Opening and ending tag mismatch: EmailAdr line 119 and OrgId
FAIL  examples/general/example_AppHdr.xml  [well-formedness]: 122:22: Opening and ending tag mismatch: CtctDtls line 116 and Fr
FAIL  examples/general/example_AppHdr.xml  [well-formedness]: 208:20: Opening and ending tag mismatch: OrgId line 105 and Rltd
FAIL  examples/general/example_AppHdr.xml  [well-formedness]: 209:18: Opening and ending tag mismatch: Fr line 104 and AppHdr
FAIL  examples/general/example_AppHdr.xml  [head.001.001.01.xsd]: 118:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/general/example_AppHdr.xml  [head.001.001.01.xsd]: 119:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/general/example_AppHdr.xml  [head.001.001.01.xsd]: 123:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/general/example_AppHdr.xml  [head.001.001.01.xsd]: 102:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}Rltd': Missing child element(s). Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/general/example_AppHdr.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/example_AppHdr.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/example_AppHdr.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/example_AppHdr.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/general/example_AppHdr.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/general/example_AppHdr.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 23:44: Opening and ending tag mismatch: EmailAdr line 22 and CtctDtls
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 24:37: Opening and ending tag mismatch: EmailAdr line 22 and OrgId
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 25:30: Opening and ending tag mismatch: CtctDtls line 19 and Fr
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 111:30: Opening and ending tag mismatch: OrgId line 8 and AppHdr
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 159:29: Opening and ending tag mismatch: Fr line 7 and QueryRequest
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 160:20: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/general/example_passing_sender_details.xml  [well-formedness]: 161:20: Opening and ending tag mismatch: QueryRequest line 4 and Envelope
FAIL  examples/general/example_passing_sender_details.xml  [head.001.001.01.xsd]: 21:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/general/example_passing_sender_details.xml  [head.001.001.01.xsd]: 22:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/general/example_passing_sender_details.xml  [head.001.001.01.xsd]: 26:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/general/example_passing_sender_details.xml  [head.001.001.01.xsd]: 112:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.001.001.01}Document': This element is not expected.
FAIL  examples/general/example_passing_sender_details.xml  [head.001.001.01.xsd]: 5:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Missing child element(s). Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/general/example_passing_sender_details.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/general/example_passing_sender_details.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/general/example_passing_sender_details.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/general/example_passing_sender_details.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/general/example_passing_sender_details.xml  [auth.001.001.01.xsd]
FAIL  examples/general/example_passing_sender_details.xml  [fin.012.001.04.xsd]: 145:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}RequestedDataSources': This element is not expected. Expected is ( {urn:fin.012.001.04}AuthorityInquiry ).
FAIL  examples/general/example_request_additional_info.xml  [head.001.001.01.xsd]: 4:0:ERROR:SCHEMASV:SCHEMAV_CVC_COMPLEX_TYPE_2_3: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Character content other than whitespace is not allowed because the content type is 'element-only'.
FAIL  examples/general/example_request_additional_info.xml  [head.001.001.01.xsd]: 4:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Missing child element(s). Expected is one of ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}CharSet, {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}Fr ).
OK    examples/general/example_request_additional_info.xml  [auth.001.001.01.xsd]
FAIL  examples/general/example_request_additional_info.xml  [fin.012.001.04.xsd]: 38:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}officialId': This element is not expected. Expected is one of ( {urn:fin.012.001.04}OfficialId, {urn:fin.012.001.04}OfficialSuperiorId, {urn:fin.012.001.04}OfficialOrgId ).
FAIL  examples/general/example_requesting_only_bal_or_entry_or_both.xml  [head.001.001.01.xsd]: 4:0:ERROR:SCHEMASV:SCHEMAV_CVC_COMPLEX_TYPE_2_3: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Character content other than whitespace is not allowed because the content type is 'element-only'.
FAIL  examples/general/example_requesting_only_bal_or_entry_or_both.xml  [head.001.001.01.xsd]: 4:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Missing child element(s). Expected is one of ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}CharSet, {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}Fr ).
OK    examples/general/example_requesting_only_bal_or_entry_or_both.xml  [auth.001.001.01.xsd]
FAIL  examples/general/example_requesting_only_bal_or_entry_or_both.xml  [fin.012.001.04.xsd]: 37:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}RequestedDataSources': This element is not expected. Expected is ( {urn:fin.012.001.04}AuthorityInquiry ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 23:44: Opening and ending tag mismatch: EmailAdr line 22 and CtctDtls
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 24:37: Opening and ending tag mismatch: EmailAdr line 22 and OrgId
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 25:30: Opening and ending tag mismatch: CtctDtls line 19 and Fr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 111:30: Opening and ending tag mismatch: OrgId line 8 and AppHdr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 160:35: Opening and ending tag mismatch: Fr line 7 and ApplicationRequest
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 161:20: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [well-formedness]: 162:20: Opening and ending tag mismatch: ApplicationRequest line 4 and Envelope
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 21:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 22:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 26:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 112:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.001.001.01}Document': This element is not expected.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 5:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Missing child element(s). Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [auth.001.001.01.xsd]
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [fin.012.001.04.xsd]: 148:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}officialOrgId': This element is not expected. Expected is ( {urn:fin.012.001.04}OfficialOrgId ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 23:44: Opening and ending tag mismatch: EmailAdr line 22 and CtctDtls
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 24:37: Opening and ending tag mismatch: EmailAdr line 22 and OrgId
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 25:30: Opening and ending tag mismatch: CtctDtls line 19 and Fr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 111:30: Opening and ending tag mismatch: OrgId line 8 and AppHdr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 165:35: Opening and ending tag mismatch: Fr line 7 and ApplicationRequest
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 166:20: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [well-formedness]: 167:20: Opening and ending tag mismatch: ApplicationRequest line 4 and Envelope
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]: 21:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]: 22:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]: 26:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]: 112:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.001.001.01}Document': This element is not expected.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]: 5:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Missing child element(s). Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [auth.001.001.01.xsd]
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [code:ExternalAccountIdentification1Code]: 'OTHR' is not a valid ExternalAccountIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [fin.012.001.04.xsd]: 153:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}officialOrgId': This element is not expected. Expected is ( {urn:fin.012.001.04}OfficialOrgId ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 119:48: Opening and ending tag mismatch: EmailAdr line 118 and CtctDtls
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 120:41: Opening and ending tag mismatch: EmailAdr line 118 and OrgId
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 121:34: Opening and ending tag mismatch: CtctDtls line 115 and Fr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 212:32: Opening and ending tag mismatch: OrgId line 104 and Rltd
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 213:30: Opening and ending tag mismatch: Fr line 103 and AppHdr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 1034:36: Opening and ending tag mismatch: Rltd line 101 and ApplicationResponse
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 1035:21: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [well-formedness]: 1036:21: Opening and ending tag mismatch: ApplicationResponse line 4 and Envelope
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [head.001.001.01.xsd]: 117:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [head.001.001.01.xsd]: 118:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [head.001.001.01.xsd]: 122:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [head.001.001.01.xsd]: 214:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.002.001.01}Document': This element is not expected. Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [auth.002.001.01.xsd]
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [camt.052.001.08.xsd]: 364:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:camt.052.001.08}NbOfTxs': [facet 'pattern'] The value 'Number of transactions in the batch' is not accepted by the pattern '[0-9]{1,15}'.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalOrganisationIdentification1Code]: 'y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalFinancialInstitutionIdentification1Code]: 'y' is not a valid ExternalFinancialInstitutionIdentification1Code (no such ISO code set -- use Prtry)
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [code:ExternalPurpose1Code]: 'DIVI' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 120:48: Opening and ending tag mismatch: EmailAdr line 119 and CtctDtls
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 121:41: Opening and ending tag mismatch: EmailAdr line 119 and OrgId
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 122:34: Opening and ending tag mismatch: CtctDtls line 116 and Fr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 213:32: Opening and ending tag mismatch: OrgId line 105 and Rltd
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 214:30: Opening and ending tag mismatch: Fr line 104 and AppHdr
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 1035:36: Opening and ending tag mismatch: Rltd line 102 and ApplicationResponse
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 1036:21: Opening and ending tag mismatch: AppHdr line 6 and Body
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [well-formedness]: 1037:21: Opening and ending tag mismatch: ApplicationResponse line 5 and Envelope
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [head.001.001.01.xsd]: 118:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [head.001.001.01.xsd]: 119:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [head.001.001.01.xsd]: 123:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [head.001.001.01.xsd]: 215:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.002.001.01}Document': This element is not expected. Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [auth.002.001.01.xsd]
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalOrganisationIdentification1Code]: 'y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalFinancialInstitutionIdentification1Code]: 'y' is not a valid ExternalFinancialInstitutionIdentification1Code (no such ISO code set -- use Prtry)
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalPurpose1Code]: 'ExternalPurpose1Code' is not a valid ExternalPurpose1Code
FAIL  examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [code:ExternalCashAccountType1Code]: 'ExternalCashAccountType1Code' is not a valid ExternalCashAccountType1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 23:44: Opening and ending tag mismatch: EmailAdr line 22 and CtctDtls
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 24:37: Opening and ending tag mismatch: EmailAdr line 22 and OrgId
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 25:30: Opening and ending tag mismatch: CtctDtls line 19 and Fr
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 111:30: Opening and ending tag mismatch: OrgId line 8 and AppHdr
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 163:29: Opening and ending tag mismatch: Fr line 7 and QueryRequest
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 164:20: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [well-formedness]: 165:20: Opening and ending tag mismatch: QueryRequest line 4 and Envelope
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 21:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 22:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 26:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 112:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.001.001.01}Document': This element is not expected.
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]: 5:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}AppHdr': Missing child element(s). Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [auth.001.001.01.xsd]
FAIL  examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [fin.012.001.04.xsd]: 148:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}officialOrgId': This element is not expected. Expected is ( {urn:fin.012.001.04}OfficialOrgId ).
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 5:28: Namespace prefix head001 on AppHdr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 6:33: Namespace prefix head001 on CharSet is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 7:28: Namespace prefix head001 on Fr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 8:35: Namespace prefix head001 on OrgId is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 9:36: Namespace prefix head001 on Id is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 10:43: Namespace prefix head001 on OrgId is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 11:46: Namespace prefix head001 on Othr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 12:48: Namespace prefix head001 on Id is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 13:53: Namespace prefix head001 on SchmeNm is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 14:52: Namespace prefix head001 on Cd is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 19:42: Namespace prefix head001 on CtctDtls is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 20:40: Namespace prefix head001 on Nm is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 21:44: Namespace prefix head001 on PhneNb is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 22:46: Namespace prefix head001 on EmailAdr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 22:92: Namespace prefix head001 on EmailAdr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 23:44: Opening and ending tag mismatch: EmailAdr line 22 and CtctDtls
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 24:37: Opening and ending tag mismatch: EmailAdr line 22 and OrgId
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 25:30: Opening and ending tag mismatch: CtctDtls line 19 and Fr
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 26:28: Namespace prefix head001 on To is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 27:35: Namespace prefix head001 on OrgId is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 28:36: Namespace prefix head001 on Id is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 29:43: Namespace prefix head001 on OrgId is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 30:46: Namespace prefix head001 on Othr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 31:48: Namespace prefix head001 on Id is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 32:53: Namespace prefix head001 on SchmeNm is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 33:52: Namespace prefix head001 on Cd is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 40:35: Namespace prefix head001 on BizMsgIdr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 41:35: Namespace prefix head001 on MsgDefIdr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 42:31: Namespace prefix head001 on CreDt is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 43:31: Namespace prefix head001 on Sgntr is not defined
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 111:30: Opening and ending tag mismatch: OrgId line 8 and AppHdr
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 168:29: Opening and ending tag mismatch: Fr line 7 and QueryRequest
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 169:20: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [well-formedness]: 170:20: Opening and ending tag mismatch: QueryRequest line 4 and Envelope
OK    examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [auth.001.001.01.xsd]
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [code:ExternalAccountIdentification1Code]: 'OTHR' is not a valid ExternalAccountIdentification1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [fin.012.001.04.xsd]: 153:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:fin.012.001.04}officialOrgId': This element is not expected. Expected is ( {urn:fin.012.001.04}OfficialOrgId ).
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 119:48: Opening and ending tag mismatch: EmailAdr line 118 and CtctDtls
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 120:41: Opening and ending tag mismatch: EmailAdr line 118 and OrgId
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 121:34: Opening and ending tag mismatch: CtctDtls line 115 and Fr
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 212:32: Opening and ending tag mismatch: OrgId line 104 and Rltd
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 213:30: Opening and ending tag mismatch: Fr line 103 and AppHdr
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 1050:31: Opening and ending tag mismatch: Rltd line 101 and ResultResponse
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 1051:21: Opening and ending tag mismatch: AppHdr line 5 and Body
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [well-formedness]: 1052:21: Opening and ending tag mismatch: ResultResponse line 4 and Envelope
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [head.001.001.01.xsd]: 117:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}PhneNb': [facet 'pattern'] The value 'Virkailijan puhelinnumero' is not accepted by the pattern '\+[0-9]{1,3}-[0-9()+\-]{1,30}'.
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [head.001.001.01.xsd]: 118:0:ERROR:SCHEMASV:SCHEMAV_CVC_TYPE_3_1_2: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}EmailAdr': Element content is not allowed, because the type definition is simple.
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [head.001.001.01.xsd]: 122:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To': This element is not expected.
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [head.001.001.01.xsd]: 214:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element '{urn:iso:std:iso:20022:tech:xsd:auth.002.001.01}Document': This element is not expected. Expected is ( {urn:iso:std:iso:20022:tech:xsd:head.001.001.01}To ).
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [value:EmailAdr]: not a valid email address: 'Virkailijan sähköpostiosoite'
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [value:EmailAdr]: not a valid email address: ''
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalOrganisationIdentification1Code]: 'Y' is not a valid ExternalOrganisationIdentification1Code
OK    examples/queries_and_responses/data_users/Camt_052_result_response.xml  [auth.002.001.01.xsd]
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [camt.052.001.08.xsd]: 380:0:ERROR:SCHEMASV:SCHEMAV_CVC_PATTERN_VALID: Element '{urn:iso:std:iso:20022:tech:xsd:camt.052.001.08}NbOfTxs': [facet 'pattern'] The value 'Number of transactions in the batch' is not accepted by the pattern '[0-9]{1,15}'.
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalOrganisationIdentification1Code]: 'y' is not a valid ExternalOrganisationIdentification1Code
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalFinancialInstitutionIdentification1Code]: 'y' is not a valid ExternalFinancialInstitutionIdentification1Code (no such ISO code set -- use Prtry)
FAIL  examples/queries_and_responses/data_users/Camt_052_result_response.xml  [code:ExternalPurpose1Code]: 'DIVI' is not a valid ExternalPurpose1Code

12 file(s): 12 with issues, 222 issue(s) total, 0 unmatched.
```

**After (this branch):**

```text
➜ python examples/validate.py
OK    examples/general/NRES_response.xml  [head.001.001.01.xsd]
OK    examples/general/NRES_response.xml  [auth.002.001.01.xsd]
OK    examples/general/example_AppHdr.xml  [head.001.001.01.xsd]
OK    examples/general/example_passing_sender_details.xml  [head.001.001.01.xsd]
OK    examples/general/example_passing_sender_details.xml  [auth.001.001.01.xsd]
OK    examples/general/example_passing_sender_details.xml  [fin.012.001.04.xsd]
OK    examples/general/example_request_additional_info.xml  [head.001.001.01.xsd]
OK    examples/general/example_request_additional_info.xml  [auth.001.001.01.xsd]
OK    examples/general/example_request_additional_info.xml  [fin.012.001.04.xsd]
OK    examples/general/example_requesting_only_bal_or_entry_or_both.xml  [head.001.001.01.xsd]
OK    examples/general/example_requesting_only_bal_or_entry_or_both.xml  [auth.001.001.01.xsd]
OK    examples/general/example_requesting_only_bal_or_entry_or_both.xml  [fin.012.001.04.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [auth.001.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_IBAN.xml  [fin.012.001.04.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [auth.001.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_query_OTHER.xml  [fin.012.001.04.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [auth.002.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_response.xml  [camt.052.001.08.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [auth.002.001.01.xsd]
OK    examples/queries_and_responses/data_suppliers/Camt_052_response_for_data_disclosure_system.xml  [camt.052.001.08.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [auth.001.001.01.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_query_IBAN.xml  [fin.012.001.04.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [auth.001.001.01.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_query_OTHER.xml  [fin.012.001.04.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_result_response.xml  [head.001.001.01.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_result_response.xml  [auth.002.001.01.xsd]
OK    examples/queries_and_responses/data_users/Camt_052_result_response.xml  [camt.052.001.08.xsd]

12 file(s): 0 with issues, 0 issue(s) total, 0 unmatched.
```